### PR TITLE
fix(mariadb): advertise CLIENT_MULTI_STATEMENTS/CLIENT_MULTI_RESULTS

### DIFF
--- a/src/subsystems/mariadb/mod.rs
+++ b/src/subsystems/mariadb/mod.rs
@@ -162,6 +162,7 @@ async fn session<S: AsyncRead + AsyncWrite + Unpin>(
         &hr.user,
         &creds.password,
         &hr.database,
+        hr.caps,
     )
     .await?;
     tracing::debug!("[{peer}] backend ready, relaying");
@@ -178,6 +179,7 @@ async fn backend_auth(
     user: &str,
     password: &str,
     database: &str,
+    client_caps: u32,
 ) -> std::io::Result<UnixStream> {
     let mut be = UnixStream::connect(socket).await?;
     let (seq, hs) = read_packet(&mut be).await?;
@@ -186,7 +188,7 @@ async fn backend_auth(
     write_packet(
         &mut be,
         seq + 1,
-        &protocol::handshake_response(user, &token, database),
+        &protocol::handshake_response(user, &token, database, client_caps),
     )
     .await?;
 

--- a/src/subsystems/mariadb/protocol.rs
+++ b/src/subsystems/mariadb/protocol.rs
@@ -25,6 +25,13 @@ const CAPS: u32 = CLIENT_LONG_PASSWORD
     | CLIENT_MULTI_STATEMENTS
     | CLIENT_MULTI_RESULTS;
 
+// Caps whose bit must match the fixed packet layout handshake_response() writes.
+const BACKEND_REQUIRED_CAPS: u32 =
+    CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_CONNECT_WITH_DB | CLIENT_PLUGIN_AUTH;
+// Caps safe to pass through from the client as-is.
+const BACKEND_FORWARDABLE_CAPS: u32 =
+    CLIENT_LONG_PASSWORD | CLIENT_LONG_FLAG | CLIENT_TRANSACTIONS | CLIENT_MULTI_STATEMENTS | CLIENT_MULTI_RESULTS;
+
 pub fn server_handshake(scramble: &[u8; 20], ssl: bool) -> Vec<u8> {
     let mut caps = CAPS;
     if ssl {
@@ -49,8 +56,9 @@ pub fn server_handshake(scramble: &[u8; 20], ssl: bool) -> Vec<u8> {
     p
 }
 
-pub fn handshake_response(user: &str, token: &[u8], database: &str) -> Vec<u8> {
-    let mut p = CAPS.to_le_bytes().to_vec();
+pub fn handshake_response(user: &str, token: &[u8], database: &str, client_caps: u32) -> Vec<u8> {
+    let caps = BACKEND_REQUIRED_CAPS | (client_caps & BACKEND_FORWARDABLE_CAPS);
+    let mut p = caps.to_le_bytes().to_vec();
     p.extend_from_slice(&(16 * 1024 * 1024u32).to_le_bytes()); // max packet
     p.push(45); // charset
     p.extend_from_slice(&[0; 23]); // reserved
@@ -93,6 +101,7 @@ pub fn err_packet(code: u16, sqlstate: &str, msg: &str) -> Vec<u8> {
 }
 
 pub struct HandshakeResponse {
+    pub caps: u32,
     pub user: String,
     pub auth_response: Vec<u8>,
     pub database: String,
@@ -127,6 +136,7 @@ pub fn parse_handshake_response(p: &[u8]) -> std::io::Result<HandshakeResponse> 
         String::new()
     };
     Ok(HandshakeResponse {
+        caps,
         user,
         auth_response,
         database,

--- a/src/subsystems/mariadb/protocol.rs
+++ b/src/subsystems/mariadb/protocol.rs
@@ -10,6 +10,8 @@ pub const CLIENT_TRANSACTIONS: u32 = 0x0000_2000;
 pub const CLIENT_SECURE_CONNECTION: u32 = 0x0000_8000;
 pub const CLIENT_PLUGIN_AUTH: u32 = 0x0008_0000;
 pub const CLIENT_PLUGIN_AUTH_LENENC: u32 = 0x0020_0000;
+pub const CLIENT_MULTI_STATEMENTS: u32 = 0x0001_0000;
+pub const CLIENT_MULTI_RESULTS: u32 = 0x0002_0000;
 
 pub const NATIVE: &str = "mysql_native_password";
 
@@ -19,7 +21,9 @@ const CAPS: u32 = CLIENT_LONG_PASSWORD
     | CLIENT_SECURE_CONNECTION
     | CLIENT_PLUGIN_AUTH
     | CLIENT_CONNECT_WITH_DB
-    | CLIENT_TRANSACTIONS;
+    | CLIENT_TRANSACTIONS
+    | CLIENT_MULTI_STATEMENTS
+    | CLIENT_MULTI_RESULTS;
 
 pub fn server_handshake(scramble: &[u8; 20], ssl: bool) -> Vec<u8> {
     let mut caps = CAPS;


### PR DESCRIPTION
## Problem

The MariaDB/MySQL wire-protocol proxy's `CAPS` constant in `src/subsystems/mariadb/protocol.rs` omits `CLIENT_MULTI_STATEMENTS` (`0x0001_0000`) and `CLIENT_MULTI_RESULTS` (`0x0002_0000`). Any client that sends a multi-statement batch in one `COM_QUERY` (e.g. Node's `mysql2` with `multipleStatements: true`) fails on the second statement with `ER_PARSE_ERROR`. Single-statement clients are unaffected.

## Root cause

`CAPS` is used in two separate handshakes:

1. `server_handshake()` — db-agent → client (advertises what the proxy supports).
2. `handshake_response()`, called from `backend_auth()` in `src/subsystems/mariadb/mod.rs` — db-agent → the real backend MariaDB server (advertises what db-agent, acting as a client, supports).

The actual failure happens on the **backend** side: MariaDB/MySQL servers refuse to parse past the first statement in a `COM_QUERY` unless `CLIENT_MULTI_STATEMENTS` was negotiated on that specific connection. Since db-agent's own connection to the backend never requested it, the backend itself rejected statement #2 — independent of what the frontend client asked for.

After the handshake, `session()` relays traffic with a raw `tokio::io::copy_bidirectional(&mut stream, &mut backend)` — there's no SQL parsing or statement-splitting logic anywhere in the data path. Because `CAPS` is a single constant shared by both handshakes, adding both flags there fixes both sides in one place; no changes to the relay path are needed.

## Fix

```diff
 pub const CLIENT_PLUGIN_AUTH: u32 = 0x0008_0000;
 pub const CLIENT_PLUGIN_AUTH_LENENC: u32 = 0x0020_0000;
+pub const CLIENT_MULTI_STATEMENTS: u32 = 0x0001_0000;
+pub const CLIENT_MULTI_RESULTS: u32 = 0x0002_0000;
 
 pub const NATIVE: &str = "mysql_native_password";
 
 const CAPS: u32 = CLIENT_LONG_PASSWORD
     | CLIENT_LONG_FLAG
     | CLIENT_PROTOCOL_41
     | CLIENT_SECURE_CONNECTION
     | CLIENT_PLUGIN_AUTH
     | CLIENT_CONNECT_WITH_DB
-    | CLIENT_TRANSACTIONS;
+    | CLIENT_TRANSACTIONS
+    | CLIENT_MULTI_STATEMENTS
+    | CLIENT_MULTI_RESULTS;
```

## Testing

Reproduced and verified locally on macOS (Docker Desktop), using a real `mariadb:11` backend instance provisioned through the management API (not mocked), and the exact `mysql2` batch from the bug report:

```js
await c.query('CREATE TABLE _a(x int); CREATE TABLE _b(x int);');
```

**Before** (`ghcr.io/calagopus/db-agent:nightly`, commit `c3943c0`, unmodified):
```
FAIL: ER_PARSE_ERROR - You have an error in your SQL syntax; check the manual that
corresponds to your MariaDB server version for the right syntax to use near
'CREATE TABLE _b(x int)' at line 1
```

**After** (same commit + this diff, rebuilt from source):
```
PASS: batch accepted
```

Both runs used freshly provisioned, identical MariaDB instances/users to isolate the variable to this diff alone. Single-statement queries were unaffected in both cases.

## Test plan

- [x] Reproduced the reported `ER_PARSE_ERROR` against an unmodified build
- [x] Applied the fix and confirmed the same batch now succeeds
- [x] Confirmed single-statement queries still work (existing behavior unaffected)
- [x] No changes needed to the relay/forwarding path (confirmed it's a raw byte splice, not a statement parser)