### PR TITLE
add unauthenticated /api/health endpoint

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -29,3 +29,11 @@ services:
       - 6379:6379
       # Management API (config: api.bind)
       - 8090:8090
+    # unauthenticated health check, reports 503 while any enabled subsystem is not serving.
+    # adjust the port if you change api.bind, and use https:// if api.tls.enabled is set
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:8090/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3

--- a/src/routes/api/health/mod.rs
+++ b/src/routes/api/health/mod.rs
@@ -1,0 +1,224 @@
+use super::State;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+mod get {
+    use crate::{
+        instance::resources::ContainerState,
+        response::{ApiResponse, ApiResponseResult},
+        routes::GetState,
+        subsystems::status::Connections,
+    };
+    use axum::http::{HeaderMap, StatusCode};
+    use serde::Serialize;
+    use utoipa::ToSchema;
+
+    #[derive(ToSchema, Serialize, Clone, Copy, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    enum HealthStatus {
+        Healthy,
+        Degraded,
+        Unhealthy,
+    }
+
+    #[derive(ToSchema, Serialize)]
+    struct ResponseService {
+        status: HealthStatus,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        bind: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tls: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        connections: Option<Connections>,
+    }
+
+    #[derive(ToSchema, Serialize)]
+    struct ResponseServices {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        postgres: Option<ResponseService>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mariadb: Option<ResponseService>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mongodb: Option<ResponseService>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        redis: Option<ResponseService>,
+
+        database: ResponseService,
+    }
+
+    #[derive(ToSchema, Serialize)]
+    struct ResponseInstances {
+        total: usize,
+        online: usize,
+        offline: usize,
+    }
+
+    #[derive(ToSchema, Serialize)]
+    struct Response<'a> {
+        status: HealthStatus,
+
+        #[schema(inline)]
+        services: ResponseServices,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uptime: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        container_type: Option<crate::routes::AppContainerType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schema(inline)]
+        instances: Option<ResponseInstances>,
+    }
+
+    /// Builds the status of a single subsystem, or `None` if it is disabled in the config.
+    ///
+    /// `detailed` gates everything an unauthenticated caller must not see: the address the proxy
+    /// listens on, whether it terminates TLS, and how many connections it is serving.
+    fn service(
+        enabled: bool,
+        bind: &std::net::SocketAddr,
+        tls: bool,
+        status: crate::subsystems::status::SubsystemStatus,
+        detailed: bool,
+    ) -> Option<ResponseService> {
+        if !enabled {
+            return None;
+        }
+
+        Some(ResponseService {
+            status: if status.running {
+                HealthStatus::Healthy
+            } else {
+                HealthStatus::Unhealthy
+            },
+            bind: detailed.then(|| bind.to_string()),
+            tls: detailed.then_some(tls),
+            connections: detailed.then_some(status.connections),
+        })
+    }
+
+    /// Unauthenticated health check. Reports whether the api and every subsystem enabled in the
+    /// config is serving, and nothing more.
+    ///
+    /// Supplying a valid `Authorization: Bearer <token>` header additionally reports the agent
+    /// version, uptime, instance counts and per-subsystem bind addresses and connection counts.
+    /// Responds with `503` if any enabled subsystem is not healthy.
+    #[utoipa::path(get, path = "/", responses(
+        (status = OK, body = inline(Response)),
+        (status = SERVICE_UNAVAILABLE, body = inline(Response)),
+    ), security(
+        (),
+        ("api_key" = []),
+    ))]
+    pub async fn route(state: GetState, headers: HeaderMap) -> ApiResponseResult {
+        let detailed = crate::routes::api::is_authenticated(&state, &headers);
+
+        let database_healthy = sqlx::query("SELECT 1")
+            .fetch_optional(state.database.read())
+            .await
+            .inspect_err(|err| tracing::error!("health check database probe failed: {err:#?}"))
+            .is_ok();
+
+        let mut instances = None;
+        if detailed {
+            let mut counts = ResponseInstances {
+                total: 0,
+                online: 0,
+                offline: 0,
+            };
+
+            for instance in state.instance_manager.get_instances().await.iter() {
+                counts.total += 1;
+                if instance.resource_usage().await.state == ContainerState::Offline {
+                    counts.offline += 1;
+                } else {
+                    counts.online += 1;
+                }
+            }
+
+            instances = Some(counts);
+        }
+
+        // everything below is synchronous, the config guard is never held across an await
+        let config = state.config.load();
+
+        let services = ResponseServices {
+            postgres: service(
+                config.postgres.enabled,
+                &config.postgres.bind,
+                config.postgres.tls.enabled,
+                state.subsystem_registry.postgres.snapshot(),
+                detailed,
+            ),
+            mariadb: service(
+                config.mariadb.enabled,
+                &config.mariadb.bind,
+                config.mariadb.tls.enabled,
+                state.subsystem_registry.mariadb.snapshot(),
+                detailed,
+            ),
+            mongodb: service(
+                config.mongodb.enabled,
+                &config.mongodb.bind,
+                config.mongodb.tls.enabled,
+                state.subsystem_registry.mongodb.snapshot(),
+                detailed,
+            ),
+            redis: service(
+                config.redis.enabled,
+                &config.redis.bind,
+                config.redis.tls.enabled,
+                state.subsystem_registry.redis.snapshot(),
+                detailed,
+            ),
+            database: ResponseService {
+                status: if database_healthy {
+                    HealthStatus::Healthy
+                } else {
+                    HealthStatus::Unhealthy
+                },
+                bind: None,
+                tls: None,
+                connections: None,
+            },
+        };
+
+        // the api answered, so it is never fully unhealthy here, only degraded
+        let degraded = [
+            services.postgres.as_ref(),
+            services.mariadb.as_ref(),
+            services.mongodb.as_ref(),
+            services.redis.as_ref(),
+            Some(&services.database),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|service| service.status != HealthStatus::Healthy);
+
+        ApiResponse::new_serialized(Response {
+            status: if degraded {
+                HealthStatus::Degraded
+            } else {
+                HealthStatus::Healthy
+            },
+            services,
+            version: detailed.then_some(state.version.as_str()),
+            uptime: detailed.then_some(state.start_time.elapsed().as_secs()),
+            container_type: detailed.then_some(state.container_type),
+            instances,
+        })
+        .with_status(if degraded {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::OK
+        })
+        .ok()
+    }
+}
+
+pub fn router(state: &State) -> OpenApiRouter<State> {
+    OpenApiRouter::new()
+        .routes(routes!(get::route))
+        .with_state(state.clone())
+}

--- a/src/routes/api/mod.rs
+++ b/src/routes/api/mod.rs
@@ -9,49 +9,64 @@ use axum::{
 };
 use utoipa_axum::router::OpenApiRouter;
 
+mod health;
 mod instances;
 mod status;
 mod system;
 
-pub async fn auth(state: GetState, req: Request, next: Next) -> Result<Response<Body>, StatusCode> {
-    let key = req
-        .headers()
+enum AuthResult {
+    Ok,
+    InvalidHeader,
+    InvalidToken,
+}
+
+fn check_auth(state: &State, headers: &axum::http::HeaderMap) -> AuthResult {
+    let key = headers
         .get("Authorization")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
     let (r#type, token) = match key.split_once(' ') {
         Some((t, tok)) => (t, tok),
-        None => {
-            return Ok(ApiResponse::error("invalid authorization header")
-                .with_status(StatusCode::UNAUTHORIZED)
-                .with_header("WWW-Authenticate", "Bearer")
-                .into_response());
-        }
+        None => return AuthResult::InvalidHeader,
     };
 
     if r#type != "Bearer" {
-        return Ok(ApiResponse::error("invalid authorization header")
-            .with_status(StatusCode::UNAUTHORIZED)
-            .with_header("WWW-Authenticate", "Bearer")
-            .into_response());
+        return AuthResult::InvalidHeader;
     }
 
     let expected = state.config.load().api.token.clone();
     if expected.is_empty()
         || !constant_time_eq::constant_time_eq(token.as_bytes(), expected.as_bytes())
     {
-        return Ok(ApiResponse::error("invalid authorization token")
-            .with_status(StatusCode::UNAUTHORIZED)
-            .with_header("WWW-Authenticate", "Bearer")
-            .into_response());
+        return AuthResult::InvalidToken;
     }
 
-    Ok(next.run(req).await)
+    AuthResult::Ok
+}
+
+/// Whether the request carries a valid api token, for routes that are reachable without one but
+/// reveal more when it is present.
+pub fn is_authenticated(state: &State, headers: &axum::http::HeaderMap) -> bool {
+    matches!(check_auth(state, headers), AuthResult::Ok)
+}
+
+pub async fn auth(state: GetState, req: Request, next: Next) -> Result<Response<Body>, StatusCode> {
+    let error = match check_auth(&state, req.headers()) {
+        AuthResult::Ok => return Ok(next.run(req).await),
+        AuthResult::InvalidHeader => "invalid authorization header",
+        AuthResult::InvalidToken => "invalid authorization token",
+    };
+
+    Ok(ApiResponse::error(error)
+        .with_status(StatusCode::UNAUTHORIZED)
+        .with_header("WWW-Authenticate", "Bearer")
+        .into_response())
 }
 
 pub fn router(state: &State) -> OpenApiRouter<State> {
     OpenApiRouter::new()
+        .nest("/health", health::router(state))
         .nest(
             "/instances",
             instances::router(state)


### PR DESCRIPTION
Adds `GET /api/health` so the agent can be probed by container healthchecks, load balancers and uptime monitors without handing them an api token.

### Behaviour

Unauthenticated callers get a status for the api and for each subsystem **enabled in the config**, and nothing else:

```json
{"status":"healthy","services":{"postgres":{"status":"healthy"},"mariadb":{"status":"healthy"},"redis":{"status":"healthy"},"database":{"status":"healthy"}}}
```

Passing a valid `Authorization: Bearer <token>` additionally reports `version`, `uptime`, `container_type`, instance counts, and each subsystem's `bind`, `tls` and connection counts:

```json
{"status":"healthy","services":{"postgres":{"status":"healthy","bind":"0.0.0.0:5432","tls":false,"connections":{"total":0,"unique_databases":0,"unique_users":0}},...},"version":"1.0.2:3fc1721@main","uptime":84213,"container_type":"official","instances":{"total":3,"online":2,"offline":1}}
```

The version string is deliberately withheld from unauthenticated callers so the endpoint cannot be used to scan for instances running a known vulnerable build. Disabled subsystems are omitted entirely rather than reported as disabled.

An invalid token does **not** produce a `401` — it falls back to the public view, so a misconfigured monitor still gets a usable probe.

The response is `503 Service Unavailable` whenever any enabled subsystem is not serving, and `200` otherwise, so a probe can act on the status code without parsing the body. The sqlite store is checked with an actual `SELECT 1` rather than assumed healthy.

### Changes

- `src/routes/api/health/mod.rs` — the new route, following the existing `mod get` / `#[utoipa::path]` layout.
- `src/routes/api/mod.rs` — nests `/health` without the bearer `route_layer` the other three nests carry. The middleware's token check is split into `check_auth` returning an `AuthResult`, so the health route can reuse it via `is_authenticated` without duplicating the constant-time comparison. `auth` maps the result back to the same two error strings; its behaviour is unchanged.
- `compose.yml` — a `healthcheck:` using busybox `wget --spider`, which is available in the alpine image.

The instance counts are only walked on the authenticated path, so the unauthenticated probe stays cheap. The config guard is not held across any `.await`.

### Testing

Verified against a running agent with a real docker socket: unauthenticated, authenticated and wrong-token responses; msgpack content negotiation; the openapi entry (`operationId: get_api_health`, `security: [{}, {api_key: []}]`, responses `200` and `503`); and the degraded path, where a subsystem pointed at an occupied port produced `503 {"status":"degraded",...}` and made the compose healthcheck command exit non-zero, returning to `200`/exit 0 once healthy. Confirmed the existing auth middleware still returns the same status and message for a missing header, a non-Bearer header, a wrong token and a valid token.

`cargo clippy --all-targets` and `cargo fmt --check` are clean.

I left this without tests to match the repo, which currently has none — happy to add some if you'd prefer. Worth flagging separately that `.github/workflows/build.yml` runs `cross test --release` across four targets and therefore currently executes zero tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)